### PR TITLE
Enable use of entire aggregation scheme

### DIFF
--- a/src/node/adult_duties/chunks/chunk_storage.rs
+++ b/src/node/adult_duties/chunks/chunk_storage.rs
@@ -22,7 +22,7 @@ use sn_messaging::{
         CmdError, Error as ErrorMessage, Message, NodeDataQueryResponse, NodeQuery,
         NodeQueryResponse, NodeSystemQuery, QueryResponse,
     },
-    DstLocation, EndUser, MessageId, SrcLocation,
+    Aggregation, DstLocation, EndUser, MessageId, SrcLocation,
 };
 use std::{
     collections::BTreeSet,
@@ -61,7 +61,7 @@ impl ChunkStorage {
                     target_section_pk: None,
                 },
                 dst: DstLocation::EndUser(origin),
-                to_be_aggregated: false, // TODO: to_be_aggregated: true,
+                aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
             }))
         } else {
             Ok(NodeMessagingDuty::NoOp)
@@ -113,7 +113,7 @@ impl ChunkStorage {
                 target_section_pk: None,
             },
             dst: DstLocation::EndUser(origin),
-            to_be_aggregated: false, // TODO: to_be_aggregated: true,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -163,7 +163,7 @@ impl ChunkStorage {
                 target_section_pk: None,
             },
             dst: origin.to_dst(),
-            to_be_aggregated: false, // TODO: to_be_aggregated: true,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -229,7 +229,7 @@ impl ChunkStorage {
                     target_section_pk: None,
                 },
                 dst: DstLocation::EndUser(origin),
-                to_be_aggregated: false, // TODO: to_be_aggregated: true,
+                aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
             }));
         }
         Ok(NodeMessagingDuty::NoOp)

--- a/src/node/elder_duties/data_section/metadata/blob_register.rs
+++ b/src/node/elder_duties/data_section/metadata/blob_register.rs
@@ -20,7 +20,7 @@ use sn_messaging::{
         BlobRead, BlobWrite, CmdError, Error as ErrorMessage, Message, NodeCmd, NodeQuery,
         NodeSystemCmd, QueryResponse,
     },
-    DstLocation, EndUser, MessageId, SrcLocation,
+    Aggregation, DstLocation, EndUser, MessageId, SrcLocation,
 };
 
 use std::{
@@ -90,7 +90,7 @@ impl BlobRegister {
                             target_section_pk: None,
                         },
                         dst: DstLocation::EndUser(origin),
-                        to_be_aggregated: false,
+                        aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
                     }));
                 }
             } else {
@@ -159,7 +159,7 @@ impl BlobRegister {
                 target_section_pk: None,
             },
             dst: DstLocation::EndUser(origin),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -348,7 +348,7 @@ impl BlobRegister {
                 NodeMessagingDuty::Send(OutgoingMsg {
                     msg,
                     dst: DstLocation::Node(dst),
-                    to_be_aggregated: false,
+                    aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
                 })
                 .into(),
             );
@@ -386,7 +386,7 @@ impl BlobRegister {
             Ok(NodeMessagingDuty::Send(OutgoingMsg {
                 msg: err_msg,
                 dst: DstLocation::EndUser(origin),
-                to_be_aggregated: false, // TODO: to_be_aggregated: true,
+                aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
             }))
         };
 

--- a/src/node/elder_duties/data_section/metadata/map_storage.rs
+++ b/src/node/elder_duties/data_section/metadata/map_storage.rs
@@ -20,7 +20,7 @@ use sn_data_types::{
 };
 use sn_messaging::{
     client::{CmdError, MapRead, MapWrite, Message, QueryResponse},
-    DstLocation, EndUser, MessageId, SrcLocation,
+    Aggregation, DstLocation, EndUser, MessageId, SrcLocation,
 };
 
 use std::fmt::{self, Display, Formatter};
@@ -233,7 +233,7 @@ impl MapStorage {
                 target_section_pk: None,
             },
             dst: DstLocation::EndUser(origin),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -261,7 +261,7 @@ impl MapStorage {
                 target_section_pk: None,
             },
             dst: DstLocation::EndUser(origin),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -289,7 +289,7 @@ impl MapStorage {
                 target_section_pk: None,
             },
             dst: DstLocation::EndUser(origin),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -327,7 +327,7 @@ impl MapStorage {
                 target_section_pk: None,
             },
             dst: DstLocation::EndUser(origin),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -355,7 +355,7 @@ impl MapStorage {
                 target_section_pk: None,
             },
             dst: DstLocation::EndUser(origin),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -384,7 +384,7 @@ impl MapStorage {
                 target_section_pk: None,
             },
             dst: DstLocation::EndUser(origin),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -413,7 +413,7 @@ impl MapStorage {
                 target_section_pk: None,
             },
             dst: DstLocation::EndUser(origin),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -441,7 +441,7 @@ impl MapStorage {
                 target_section_pk: None,
             },
             dst: DstLocation::EndUser(origin),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -473,7 +473,7 @@ impl MapStorage {
                 target_section_pk: None,
             },
             dst: DstLocation::EndUser(origin),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -496,7 +496,7 @@ impl MapStorage {
                     target_section_pk: None,
                 },
                 dst: DstLocation::EndUser(origin),
-                to_be_aggregated: false, // TODO: to_be_aggregated: true, // this needs more consideration...
+                aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,  // this needs more consideration...
             }))
         } else {
             info!("MapStorage: Writing chunk PASSED!");

--- a/src/node/elder_duties/data_section/metadata/sequence_storage.rs
+++ b/src/node/elder_duties/data_section/metadata/sequence_storage.rs
@@ -20,7 +20,7 @@ use sn_data_types::{
 };
 use sn_messaging::{
     client::{CmdError, Message, QueryResponse, SequenceRead, SequenceWrite},
-    DstLocation, EndUser, MessageId, SrcLocation,
+    Aggregation, DstLocation, EndUser, MessageId, SrcLocation,
 };
 
 use std::fmt::{self, Display, Formatter};
@@ -109,7 +109,7 @@ impl SequenceStorage {
                 target_section_pk: None,
             },
             dst: DstLocation::EndUser(origin),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -181,7 +181,7 @@ impl SequenceStorage {
                 target_section_pk: None,
             },
             dst: DstLocation::EndUser(origin),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -209,7 +209,7 @@ impl SequenceStorage {
                 target_section_pk: None,
             },
             dst: DstLocation::EndUser(origin),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -242,7 +242,7 @@ impl SequenceStorage {
                 target_section_pk: None,
             },
             dst: DstLocation::EndUser(origin),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -272,7 +272,7 @@ impl SequenceStorage {
                 target_section_pk: None,
             },
             dst: DstLocation::EndUser(origin),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -305,7 +305,7 @@ impl SequenceStorage {
                 target_section_pk: None,
             },
             dst: DstLocation::EndUser(origin),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -338,7 +338,7 @@ impl SequenceStorage {
                 target_section_pk: None,
             },
             dst: DstLocation::EndUser(origin),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -408,7 +408,7 @@ impl SequenceStorage {
                 target_section_pk: None,
             },
             dst: DstLocation::Section(origin.name()),
-            to_be_aggregated: false, // TODO: to_be_aggregated: true,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 }

--- a/src/node/elder_duties/data_section/rewards/mod.rs
+++ b/src/node/elder_duties/data_section/rewards/mod.rs
@@ -27,7 +27,7 @@ use sn_messaging::{
         Error as ErrorMessage, Message, NodeQuery, NodeQueryResponse, NodeRewardQuery,
         NodeRewardQueryResponse,
     },
-    DstLocation, MessageId, SrcLocation,
+    Aggregation, DstLocation, MessageId, SrcLocation,
 };
 
 use sn_transfers::TransferActor;
@@ -101,7 +101,7 @@ impl Rewards {
                 target_section_pk: None,
             },
             dst: DstLocation::Section(section),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         })
         .into())
     }
@@ -248,7 +248,7 @@ impl Rewards {
                 target_section_pk: None,
             },
             dst: origin.to_dst(),
-            to_be_aggregated: false, // TODO: to_be_aggregated: true,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         })
     }
 
@@ -314,7 +314,7 @@ impl Rewards {
                 target_section_pk: None,
             },
             dst: DstLocation::Section(old_node_id),
-            to_be_aggregated: false, // TODO: to_be_aggregated: true,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -439,7 +439,7 @@ impl Rewards {
                         target_section_pk: None,
                     },
                     dst: origin.to_dst(),
-                    to_be_aggregated: false, // TODO: to_be_aggregated: true,
+                    aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
                 }));
             }
         };
@@ -462,7 +462,7 @@ impl Rewards {
                 target_section_pk: None,
             },
             dst: DstLocation::Section(new_node_id),
-            to_be_aggregated: false, // TODO: to_be_aggregated: true,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 }

--- a/src/node/elder_duties/data_section/rewards/section_funds.rs
+++ b/src/node/elder_duties/data_section/rewards/section_funds.rs
@@ -21,7 +21,7 @@ use sn_data_types::{
 };
 use sn_messaging::{
     client::{Message, NodeCmd, NodeQuery, NodeTransferCmd, NodeTransferQuery},
-    DstLocation, MessageId,
+    Aggregation, DstLocation, MessageId,
 };
 use sn_transfers::{ActorEvent, TransferActor};
 use std::collections::{BTreeSet, VecDeque};
@@ -121,7 +121,7 @@ impl SectionFunds {
                 target_section_pk: None,
             },
             dst: DstLocation::Section(new_wallet.into()),
-            to_be_aggregated: false, // TODO aggregate this
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -194,7 +194,7 @@ impl SectionFunds {
                             target_section_pk: None,
                         },
                         dst: DstLocation::Section(self.actor.id().into()),
-                        to_be_aggregated: false,
+                        aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
                     }))
                 }
             }
@@ -242,7 +242,7 @@ impl SectionFunds {
                         target_section_pk: None,
                     },
                     dst: DstLocation::Section(self.actor.id().into()),
-                    to_be_aggregated: false,
+                    aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
                 }))
             }
         }
@@ -294,7 +294,7 @@ impl SectionFunds {
                     target_section_pk: None,
                 },
                 dst: DstLocation::Section(self.actor.id().into()),
-                to_be_aggregated: false, // TODO: aggregate here (not needed, but makes sn_node logs less chatty..)
+                aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination, // TODO: aggregate here (not needed, but makes sn_node logs less chatty..)
             }));
 
             // First register the transfer, then

--- a/src/node/elder_duties/key_section/transfers/mod.rs
+++ b/src/node/elder_duties/key_section/transfers/mod.rs
@@ -38,7 +38,7 @@ use sn_messaging::{
         NodeQuery, NodeQueryResponse, NodeTransferCmd, NodeTransferError, NodeTransferQuery,
         NodeTransferQueryResponse, QueryResponse, TransferError,
     },
-    DstLocation, EndUser, MessageId, SrcLocation,
+    Aggregation, DstLocation, EndUser, MessageId, SrcLocation,
 };
 use std::fmt::{self, Display, Formatter};
 use xor_name::Prefix;
@@ -105,7 +105,7 @@ impl Transfers {
                 target_section_pk: None,
             },
             dst: DstLocation::Section(pub_key.into()),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         })))
     }
 
@@ -278,7 +278,7 @@ impl Transfers {
                     target_section_pk: None,
                 },
                 dst: origin.to_dst(),
-                to_be_aggregated: false, // TODO: to_be_aggregated: true,
+                aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
             }));
         }
         let registration = self.replicas.register(&payment).await;
@@ -322,7 +322,7 @@ impl Transfers {
                             target_section_pk: None,
                         },
                         dst: origin.to_dst(),
-                        to_be_aggregated: false, // TODO: to_be_aggregated: true,
+                        aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
                     }));
                 }
                 info!("Payment: forwarding data..");
@@ -338,7 +338,7 @@ impl Transfers {
                         target_section_pk: None,
                     },
                     dst: DstLocation::Section(dst_address),
-                    to_be_aggregated: false, // TODO: to_be_aggregated: true,
+                    aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
                 }))
             }
             Err(e) => {
@@ -355,7 +355,7 @@ impl Transfers {
                         target_section_pk: None,
                     },
                     dst: origin.to_dst(),
-                    to_be_aggregated: false, // TODO: to_be_aggregated: true,
+                    aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
                 }))
             }
         }
@@ -387,7 +387,7 @@ impl Transfers {
                 target_section_pk: None,
             },
             dst: query_origin.to_dst(),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -413,7 +413,7 @@ impl Transfers {
                 target_section_pk: None,
             },
             dst: origin.to_dst(),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -435,7 +435,7 @@ impl Transfers {
                 target_section_pk: None,
             },
             dst: origin.to_dst(),
-            to_be_aggregated: false, // TODO: to_be_aggregated: true,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -462,7 +462,7 @@ impl Transfers {
                 target_section_pk: None,
             },
             dst: origin.to_dst(),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 
@@ -496,7 +496,7 @@ impl Transfers {
                 target_section_pk: None,
             },
             dst: origin.to_dst(),
-            to_be_aggregated: false, // this has to be sorted out by recipient..
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination, // this has to be sorted out by recipient..
         }))
     }
 
@@ -524,7 +524,7 @@ impl Transfers {
                 target_section_pk: None,
             },
             dst: origin.to_dst(),
-            to_be_aggregated: false, // this has to be sorted out by recipient..
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination, // this has to be sorted out by recipient..
         }))
     }
 
@@ -547,7 +547,7 @@ impl Transfers {
                     target_section_pk: None,
                 },
                 dst: origin.to_dst(),
-                to_be_aggregated: false,
+                aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
             })),
             Err(e) => {
                 let message_error = convert_to_error_message(e)?;
@@ -560,7 +560,7 @@ impl Transfers {
                         target_section_pk: None,
                     },
                     dst: origin.to_dst(),
-                    to_be_aggregated: false, // TODO: to_be_aggregated: true,
+                    aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
                 }))
             }
         }
@@ -585,7 +585,7 @@ impl Transfers {
                     target_section_pk: None,
                 },
                 dst: origin.to_dst(),
-                to_be_aggregated: false,
+                aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
             })),
             Err(e) => {
                 let message_error = convert_to_error_message(e)?;
@@ -600,7 +600,7 @@ impl Transfers {
                         target_section_pk: None,
                     },
                     dst: origin.to_dst(),
-                    to_be_aggregated: false, // TODO: to_be_aggregated: true,
+                    aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
                 }))
             }
         }
@@ -626,7 +626,7 @@ impl Transfers {
                         target_section_pk: None,
                     },
                     dst: DstLocation::Section(location),
-                    to_be_aggregated: false, // TODO: to_be_aggregated: true, // not necessary, but will be slimmer
+                    aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,  // not necessary, but will be slimmer
                 }))
             }
             Err(e) => {
@@ -642,7 +642,7 @@ impl Transfers {
                         target_section_pk: None,
                     },
                     dst: DstLocation::EndUser(EndUser::AllClients(proof.sender())),
-                    to_be_aggregated: false, // TODO: to_be_aggregated: true,
+                    aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
                 }))
             }
         }
@@ -676,7 +676,7 @@ impl Transfers {
                             target_section_pk: None,
                         },
                         dst: DstLocation::Section(location),
-                        to_be_aggregated: false, // TODO: to_be_aggregated: true,
+                        aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
                     })
                     .into(),
                 );
@@ -690,7 +690,7 @@ impl Transfers {
                             target_section_pk: None,
                         },
                         dst: DstLocation::Section(location),
-                        to_be_aggregated: false, // TODO: to_be_aggregated: true, // not necessary, but will be slimmer
+                        aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,  // not necessary, but will be slimmer
                     })
                     .into(),
                 );
@@ -709,7 +709,7 @@ impl Transfers {
                         target_section_pk: None,
                     },
                     dst: origin.to_dst(),
-                    to_be_aggregated: false, // TODO: to_be_aggregated: true,
+                    aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
                 })))
             }
         }
@@ -744,7 +744,7 @@ impl Transfers {
         Ok(NodeMessagingDuty::Send(OutgoingMsg {
             msg,
             dst: origin.to_dst(),
-            to_be_aggregated: false, // TODO: to_be_aggregated: true,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         }))
     }
 

--- a/src/node/node_duties/messaging.rs
+++ b/src/node/node_duties/messaging.rs
@@ -41,12 +41,15 @@ impl Messaging {
     }
 
     async fn send(&mut self, msg: OutgoingMsg) -> Result<NetworkDuties> {
-        let itry = Itinerary {
+        let itinerary = Itinerary {
             src: SrcLocation::Node(self.network.our_name().await),
             dst: msg.dst,
             aggregation: msg.aggregation,
         };
-        let result = self.network.send_message(itry, msg.msg.serialize()?).await;
+        let result = self
+            .network
+            .send_message(itinerary, msg.msg.serialize()?)
+            .await;
 
         result.map_or_else(
             |err| {

--- a/src/node/node_duties/mod.rs
+++ b/src/node/node_duties/mod.rs
@@ -33,7 +33,7 @@ use sn_data_types::{
 };
 use sn_messaging::{
     client::{Message, NodeCmd, NodeQuery, NodeRewardQuery, NodeSystemCmd},
-    DstLocation, MessageId, SrcLocation,
+    Aggregation, DstLocation, MessageId, SrcLocation,
 };
 use std::collections::{BTreeMap, VecDeque};
 
@@ -257,7 +257,7 @@ impl NodeDuties {
                 target_section_pk: None,
             },
             dst: DstLocation::Section(node_id.into()),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         })))
     }
 
@@ -274,7 +274,7 @@ impl NodeDuties {
                 target_section_pk: None,
             },
             dst: DstLocation::Section(wallet.into()),
-            to_be_aggregated: false,
+            aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
         })))
     }
 
@@ -352,7 +352,7 @@ impl NodeDuties {
                     target_section_pk: None,
                 },
                 dst,
-                to_be_aggregated: false,
+                aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
             })));
         } else if is_genesis_section && elder_count < GENESIS_ELDER_COUNT {
             debug!("AwaitingGenesisThreshold!");
@@ -374,7 +374,7 @@ impl NodeDuties {
                     target_section_pk: None,
                 },
                 dst: DstLocation::Section(wallet_id.into()),
-                to_be_aggregated: false,
+                aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
             })));
         }
 
@@ -421,7 +421,7 @@ impl NodeDuties {
                         target_section_pk: None,
                     },
                     dst,
-                    to_be_aggregated: false,
+                    aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
                 });
 
                 (stage, cmd)
@@ -457,7 +457,7 @@ impl NodeDuties {
                         dst: DstLocation::Section(
                             bootstrap.elder_state.section_public_key().into(),
                         ),
-                        to_be_aggregated: false,
+                        aggregation: Aggregation::None, // TODO: to_be_aggregated: Aggregation::AtDestination,
                     });
 
                     (stage, cmd)

--- a/src/node/node_ops.rs
+++ b/src/node/node_ops.rs
@@ -14,7 +14,7 @@ use sn_data_types::{
     SignedCredit, SignedTransfer, SignedTransferShare, TransferAgreementProof, TransferValidated,
     WalletInfo,
 };
-use sn_messaging::{client::Message, DstLocation, EndUser, MessageId, SrcLocation};
+use sn_messaging::{client::Message, Aggregation, DstLocation, EndUser, MessageId, SrcLocation};
 use std::fmt::Formatter;
 
 use sn_routing::{Event as RoutingEvent, Prefix};
@@ -147,7 +147,7 @@ impl Debug for NodeDuty {
 pub struct OutgoingMsg {
     pub msg: Message,
     pub dst: DstLocation,
-    pub to_be_aggregated: bool,
+    pub aggregation: Aggregation,
 }
 
 impl OutgoingMsg {


### PR DESCRIPTION
Use Aggregation enum as to allow choice of aggregation scheme. Fixes a bug where aggregation was always interpreted as `AtSource`.